### PR TITLE
update dependancies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lib/"
   ],
   "devDependencies": {
-    "chai": "^1.9.2",
+    "chai": "^3.2.0",
     "coveralls": "^2.11.2",
     "istanbul": "^0.3.5",
     "mocha": "^2.0.0",
@@ -38,7 +38,7 @@
     "sinon-chai": "^2.6.0"
   },
   "optionalDependencies": {
-    "fsevents": "^0.3.8"
+    "fsevents": "^1.0.0"
   },
   "dependencies": {
     "anymatch": "^1.1.0",
@@ -46,8 +46,8 @@
     "async-each": "^0.1.5",
     "glob-parent": "^1.0.0",
     "is-binary-path": "^1.0.0",
-    "is-glob": "^1.1.3",
+    "is-glob": "^2.0.0",
     "path-is-absolute": "^1.0.0",
-    "readdirp": "^1.3.0"
+    "readdirp": "^2.0.0"
   }
 }


### PR DESCRIPTION
npm will not throw warns like
```
> fsevents@0.3.8 install /Users/Chico/Projects/black-screen/node_modules/babel/node_modules/chokidar/node_modules/fsevents
> node-gyp rebuild

  SOLINK_MODULE(target) Release/.node
  CXX(target) Release/obj.target/fse/fsevents.o
  SOLINK_MODULE(target) Release/fse.node
npm WARN deprecated pangyp@2.3.2: use node-gyp@3+, it does all the things
```
anymore